### PR TITLE
External Resolvers Query, Pagination

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -78,37 +78,6 @@
         }
       }
     },
-    "/{identifier}": {
-      "get": {
-        "operationId": "ResolverController_resolve",
-        "parameters": [
-          {
-            "name": "identifier",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        }
-      }
-    },
-    "/.well-known/resolver": {
-      "get": {
-        "operationId": "ResolverController_getResolverMetadata",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        }
-      }
-    },
     "/external-resolvers": {
       "post": {
         "operationId": "ExternalResolveController_create",
@@ -147,6 +116,15 @@
             "description": ""
           }
         }
+      },
+      "get": {
+        "operationId": "ExternalResolveController_getMany",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
       }
     },
     "/external-resolvers/{id}": {
@@ -180,6 +158,37 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/{identifier}": {
+      "get": {
+        "operationId": "ResolverController_resolve",
+        "parameters": [
+          {
+            "name": "identifier",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/.well-known/resolver": {
+      "get": {
+        "operationId": "ResolverController_getResolverMetadata",
+        "parameters": [],
         "responses": {
           "200": {
             "description": ""

--- a/package.json
+++ b/package.json
@@ -1,32 +1,65 @@
 {
   "name": "hermes",
   "version": "0.0.1",
-  "description": "",
-  "author": "",
   "private": true,
+  "description": "",
   "license": "UNLICENSED",
+  "author": "",
   "scripts": {
     "build": "npx prisma generate && nest build",
+    "docker:down": "docker-compose down",
+    "docker:up": "docker-compose up -d postgres",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "gen:openapi": "ts-node -r tsconfig-paths/register ./scripts/gen-openapi.ts",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "precommit": "pnpm gen:openapi && git add openapi.json",
+    "prepare": "husky",
+    "prisma:generate": "npx prisma generate",
+    "prisma:push": "npx prisma db push",
     "start": "nest start",
+    "start:debug": "nest start --debug --watch",
     "start:dev": "nest start --watch",
     "start:dev:push": "pnpm run prisma:push && nest start --watch",
-    "start:debug": "nest start --debug --watch",
     "start:prod": "npx prisma migrate deploy && node dist/src/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
-    "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:e2e:watch": "jest --config ./test/jest-e2e.json --watch",
-    "docker:up": "docker-compose up -d postgres",
-    "docker:down": "docker-compose down",
-    "prisma:generate": "npx prisma generate",
-    "prisma:push": "npx prisma db push",
-    "gen:openapi": "ts-node ./scripts/gen-openapi.ts",
-    "prepare": "husky",
-    "precommit": "pnpm gen:openapi && git add openapi.json"
+    "test:watch": "jest --watch"
+  },
+  "lint-staged": {
+    "**/*": "prettier --write --ignore-unknown"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/src/$1"
+    },
+    "reporters": [
+      "default",
+      [
+        "jest-junit",
+        {
+          "outputDirectory": "./reports/junit",
+          "outputName": "unit-results.xml"
+        }
+      ]
+    ],
+    "rootDir": "src",
+    "testEnvironment": "node",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    }
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -69,35 +102,5 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.1.3"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node",
-    "reporters": [
-      "default",
-      [
-        "jest-junit",
-        {
-          "outputDirectory": "./reports/junit",
-          "outputName": "unit-results.xml"
-        }
-      ]
-    ]
-  },
-  "lint-staged": {
-    "**/*": "prettier --write --ignore-unknown"
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,7 +4,7 @@ import { LinkSetModule } from "./link-set/link-set.module";
 import { ResolverModule } from "./resolver/resolver.module";
 
 @Module({
-  imports: [LinkSetModule, ResolverModule, ExternalResolverModule],
+  imports: [LinkSetModule, ExternalResolverModule, ResolverModule],
   controllers: [],
   providers: [],
 })

--- a/src/external-resolver/external-resolver.controller.ts
+++ b/src/external-resolver/external-resolver.controller.ts
@@ -6,7 +6,9 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from "@nestjs/common";
+import { PaginationDto } from "src/shared/dto";
 import { UpsertExternalResolverSetDto } from "./external-resolver.dto";
 import { ExternalResolverService } from "./external-resolver.service";
 
@@ -29,6 +31,11 @@ export class ExternalResolveController {
   @Get(":id")
   async get(@Param("id") id: string) {
     return this.externalResolverService.get(id);
+  }
+
+  @Get()
+  async getMany(@Query() paginationDto: PaginationDto) {
+    return this.externalResolverService.getMany(paginationDto);
   }
 
   @Delete(":id")

--- a/src/external-resolver/external-resolver.service.ts
+++ b/src/external-resolver/external-resolver.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { PaginationDto } from "src/shared/dto";
 import { v4 as uuid } from "uuid";
 import { PrismaService } from "../prisma/prisma.service";
 import {
@@ -11,61 +13,80 @@ export class ExternalResolverService {
   constructor(private readonly prisma: PrismaService) {}
 
   async get(id: string): Promise<ExternalResolverSetDto> {
-    return this.prisma.externalResolverSet.findFirst({
-      where: {
-        id,
-      },
-      include: {
-        resolvers: true,
-      },
-    });
-  }
-
-  async upsertExternalResolverSet(dto: UpsertExternalResolverSetDto) {
-    return this.prisma.$transaction(async (tx) => {
-      const id = dto.id || uuid();
-
-      if (dto.id) {
-        await tx.externalResolver.deleteMany({
-          where: {
-            id: dto.id,
-          },
-        });
-      }
-
-      return tx.externalResolverSet.upsert({
+    return this.prisma.externalResolverSet
+      .findFirst({
         where: {
           id,
-        },
-        create: {
-          id,
-          pattern: dto.pattern,
-          resolvers: {
-            createMany: {
-              data: dto?.resolvers?.map((resolver) => ({
-                pattern: resolver.pattern,
-                href: resolver.href,
-              })),
-            },
-          },
-        },
-        update: {
-          id,
-          pattern: dto.pattern,
-          resolvers: {
-            createMany: {
-              data: dto?.resolvers?.map((resolver) => ({
-                pattern: resolver.pattern,
-                href: resolver.href,
-              })),
-            },
-          },
         },
         include: {
           resolvers: true,
         },
-      });
-    });
+      })
+      .then(toDto);
+  }
+
+  async getMany(pagination: PaginationDto): Promise<ExternalResolverSetDto[]> {
+    return this.prisma.externalResolverSet
+      .findMany({
+        include: {
+          resolvers: true,
+        },
+        orderBy: {
+          pattern: "asc",
+        },
+        skip: pagination?.offset ? +pagination?.offset : undefined,
+        take: pagination.limit ? +pagination.limit : undefined,
+      })
+      .then((models) => models?.map(toDto));
+  }
+
+  async upsertExternalResolverSet(dto: UpsertExternalResolverSetDto) {
+    return this.prisma
+      .$transaction(async (tx) => {
+        const id = dto.id || uuid();
+
+        if (dto.id) {
+          await tx.externalResolver.deleteMany({
+            where: {
+              id: dto.id,
+            },
+          });
+        }
+
+        return tx.externalResolverSet.upsert({
+          where: {
+            id,
+          },
+          create: {
+            id,
+            pattern: dto.pattern,
+            resolvers: {
+              createMany: {
+                data: dto?.resolvers?.map((resolver) => ({
+                  pattern: resolver.pattern,
+                  href: resolver.href,
+                })),
+              },
+            },
+          },
+          update: {
+            id,
+            pattern: dto.pattern,
+            resolvers: {
+              createMany: {
+                data: dto?.resolvers?.map((resolver) => ({
+                  pattern: resolver.pattern,
+                  href: resolver.href,
+                })),
+              },
+            },
+          },
+          include: {
+            resolvers: true,
+          },
+        });
+      })
+      .then(toDto);
   }
 
   async delete(id: string): Promise<string> {
@@ -74,3 +95,28 @@ export class ExternalResolverService {
     return id;
   }
 }
+
+const prismaDto = Prisma.validator<Prisma.ExternalResolverSetDefaultArgs>()({
+  include: {
+    resolvers: true,
+  },
+});
+
+type PrismaDTO = Prisma.ExternalResolverSetGetPayload<typeof prismaDto>;
+
+const toDto = (prismaDto: PrismaDTO): ExternalResolverSetDto => {
+  if (!prismaDto) return;
+
+  return {
+    id: prismaDto.id,
+    pattern: prismaDto.pattern,
+    updatedAt: prismaDto.updatedAt,
+    createdAt: prismaDto.createdAt,
+    resolvers: prismaDto.resolvers?.map((r) => ({
+      href: r.href,
+      pattern: r.pattern,
+      createdAt: r.createdAt,
+      updatedAt: r.updatedAt,
+    })),
+  };
+};

--- a/src/link-set/link-set.service.ts
+++ b/src/link-set/link-set.service.ts
@@ -27,7 +27,7 @@ export class LinkSetService {
         orderBy: {
           identifier: "asc",
         },
-        skip: +((pagination.page - 1) * pagination.limit || 0),
+        skip: pagination?.offset ? +pagination?.offset : undefined,
         take: pagination.limit ? +pagination.limit : undefined,
       })
       .then((models) => models?.map(toDto));

--- a/src/shared/dto.ts
+++ b/src/shared/dto.ts
@@ -6,7 +6,7 @@ export class PaginationDto {
   @Type(() => Number)
   @IsPositive()
   @Min(1)
-  page?: number = 1;
+  offset?: number = 1;
 
   @IsOptional()
   @Type(() => Number)

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,5 +1,8 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
+  },
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
     "noImplicitAny": false,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "paths": {
+      "src/*": ["./src/*"]
+    }
   }
 }


### PR DESCRIPTION
- Adding a `/GET` request to query many external resolvers
- Refined pagination support, using `offset` and `limit` parameters. 
- Updating jest configs to support `src/` imports. 