### PR TITLE
External Resolver and Link Set Resolution

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -87,7 +87,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpsertExternalResolverSetDto"
+                "$ref": "#/components/schemas/UpsertExternalResolverDto"
               }
             }
           }
@@ -106,7 +106,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpsertExternalResolverSetDto"
+                "$ref": "#/components/schemas/UpsertExternalResolverDto"
               }
             }
           }
@@ -165,19 +165,10 @@
         }
       }
     },
-    "/{identifier}": {
+    "/*": {
       "get": {
         "operationId": "ResolverController_resolve",
-        "parameters": [
-          {
-            "name": "identifier",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": ""
@@ -211,7 +202,7 @@
         "type": "object",
         "properties": {}
       },
-      "UpsertExternalResolverSetDto": {
+      "UpsertExternalResolverDto": {
         "type": "object",
         "properties": {}
       }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
     devDependencies:
+      "@faker-js/faker":
+        specifier: ^8.4.1
+        version: 8.4.1
       "@nestjs/cli":
         specifier: ^10.0.0
         version: 10.3.2
@@ -494,6 +497,13 @@ packages:
         integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==,
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+
+  "@faker-js/faker@8.4.1":
+    resolution:
+      {
+        integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==,
+      }
+    engines: { node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: ">=6.14.13" }
 
   "@humanwhocodes/config-array@0.11.14":
     resolution:
@@ -5505,6 +5515,8 @@ snapshots:
       - supports-color
 
   "@eslint/js@8.57.0": {}
+
+  "@faker-js/faker@8.4.1": {}
 
   "@humanwhocodes/config-array@0.11.14":
     dependencies:

--- a/prisma/migrations/20240717043654_link_set_external_resolver_resolution/migration.sql
+++ b/prisma/migrations/20240717043654_link_set_external_resolver_resolution/migration.sql
@@ -1,0 +1,40 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `externalResolverSetId` on the `ExternalResolver` table. All the data in the column will be lost.
+  - You are about to drop the `ExternalResolverSet` table. If the table is not empty, all the data it contains will be lost.
+  - A unique constraint covering the columns `[qualifier,pattern]` on the table `ExternalResolver` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[qualifier,identifier]` on the table `Linkset` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `qualifier` to the `ExternalResolver` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `qualifier` to the `Linkset` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ExternalResolver" DROP CONSTRAINT "ExternalResolver_externalResolverSetId_fkey";
+
+-- DropIndex
+DROP INDEX "Linkset_identifier_key";
+
+-- AlterTable
+ALTER TABLE "ExternalResolver" DROP COLUMN "externalResolverSetId",
+ADD COLUMN     "parentExternalResolverId" TEXT,
+ADD COLUMN     "qualifier" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Linkset" ADD COLUMN     "parentLinkSetId" TEXT,
+ADD COLUMN     "qualifier" TEXT NOT NULL;
+
+-- DropTable
+DROP TABLE "ExternalResolverSet";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExternalResolver_qualifier_pattern_key" ON "ExternalResolver"("qualifier", "pattern");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Linkset_qualifier_identifier_key" ON "Linkset"("qualifier", "identifier");
+
+-- AddForeignKey
+ALTER TABLE "Linkset" ADD CONSTRAINT "Linkset_parentLinkSetId_fkey" FOREIGN KEY ("parentLinkSetId") REFERENCES "Linkset"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ExternalResolver" ADD CONSTRAINT "ExternalResolver_parentExternalResolverId_fkey" FOREIGN KEY ("parentExternalResolverId") REFERENCES "ExternalResolver"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,11 +14,17 @@ datasource db {
 }
 
 model Linkset {
-  id         String   @id @default(uuid())
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  identifier String   @unique()
-  links      Link[]
+  id              String    @id @default(uuid())
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  qualifier       String
+  identifier      String
+  links           Link[]
+  childLinkSets   Linkset[] @relation(name: "ChildParent")
+  parentLinkSet   Linkset?  @relation(name: "ChildParent", fields: [parentLinkSetId], references: [id], onDelete: Cascade)
+  parentLinkSetId String?
+
+  @@unique([qualifier, identifier])
 }
 
 model Link {
@@ -33,20 +39,16 @@ model Link {
   linksetId    String
 }
 
-model ExternalResolverSet {
-  id        String             @id @default(uuid())
-  createdAt DateTime           @default(now())
-  updatedAt DateTime           @updatedAt
-  pattern   String
-  resolvers ExternalResolver[]
-}
-
 model ExternalResolver {
-  id                    String              @id @default(uuid())
-  createdAt             DateTime            @default(now())
-  updatedAt             DateTime            @updatedAt
-  href                  String
-  pattern               String
-  externalResolverSet   ExternalResolverSet @relation(fields: [externalResolverSetId], references: [id])
-  externalResolverSetId String
+  id                       String             @id @default(uuid())
+  createdAt                DateTime           @default(now())
+  updatedAt                DateTime           @updatedAt
+  qualifier                String
+  pattern                  String
+  href                     String
+  childExternalResolvers   ExternalResolver[] @relation(name: "ChildParent")
+  parentExternalResolver   ExternalResolver?  @relation(name: "ChildParent", fields: [parentExternalResolverId], references: [id], onDelete: Cascade)
+  parentExternalResolverId String?
+
+  @@unique([qualifier, pattern])
 }

--- a/src/external-resolver/external-resolver.controller.ts
+++ b/src/external-resolver/external-resolver.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
 } from "@nestjs/common";
 import { PaginationDto } from "src/shared/dto";
-import { UpsertExternalResolverSetDto } from "./external-resolver.dto";
+import { UpsertExternalResolverDto } from "./external-resolver.dto";
 import { ExternalResolverService } from "./external-resolver.service";
 
 @Controller("external-resolvers")
@@ -19,12 +19,12 @@ export class ExternalResolveController {
   ) {}
 
   @Post()
-  async create(@Body() dto: UpsertExternalResolverSetDto) {
+  async create(@Body() dto: UpsertExternalResolverDto) {
     return this.externalResolverService.upsertExternalResolverSet(dto);
   }
 
   @Put()
-  async update(@Body() dto: UpsertExternalResolverSetDto) {
+  async update(@Body() dto: UpsertExternalResolverDto) {
     return this.externalResolverService.upsertExternalResolverSet(dto);
   }
 

--- a/src/external-resolver/external-resolver.dto.ts
+++ b/src/external-resolver/external-resolver.dto.ts
@@ -9,27 +9,31 @@ import {
 
 export class UpsertExternalResolverDto {
   @IsString()
+  id?: string;
+
+  @IsString()
   href: string;
 
   @IsString()
   pattern: string;
-}
-
-export class UpsertExternalResolverSetDto {
-  @IsString()
-  id?: string;
 
   @IsString()
-  pattern: string;
+  qualifier: string;
 
   @IsArray()
   @Length(1)
   @ValidateNested({ each: true })
   @Type(() => UpsertExternalResolverDto)
-  resolvers: UpsertExternalResolverDto[];
+  childExternalResolvers?: UpsertExternalResolverDto[];
 }
 
 export class ExternalResolverDto {
+  @IsString()
+  id?: string;
+
+  @IsString()
+  qualifier: string;
+
   @IsString()
   href: string;
 
@@ -41,24 +45,10 @@ export class ExternalResolverDto {
 
   @IsDate()
   updatedAt: Date;
-}
-
-export class ExternalResolverSetDto {
-  @IsString()
-  id?: string;
-
-  @IsString()
-  pattern: string;
 
   @IsArray()
   @Length(1)
   @ValidateNested({ each: true })
   @Type(() => ExternalResolverDto)
-  resolvers: ExternalResolverDto[];
-
-  @IsDate()
-  createdAt: Date;
-
-  @IsDate()
-  updatedAt: Date;
+  childExternalResolvers?: ExternalResolverDto[];
 }

--- a/src/external-resolver/external-resolver.service.ts
+++ b/src/external-resolver/external-resolver.service.ts
@@ -4,33 +4,31 @@ import { PaginationDto } from "src/shared/dto";
 import { v4 as uuid } from "uuid";
 import { PrismaService } from "../prisma/prisma.service";
 import {
-  ExternalResolverSetDto,
-  UpsertExternalResolverSetDto,
+  ExternalResolverDto,
+  UpsertExternalResolverDto,
 } from "./external-resolver.dto";
 
 @Injectable()
 export class ExternalResolverService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async get(id: string): Promise<ExternalResolverSetDto> {
-    return this.prisma.externalResolverSet
+  async get(id: string): Promise<ExternalResolverDto> {
+    return this.prisma.externalResolver
       .findFirst({
         where: {
           id,
         },
         include: {
-          resolvers: true,
+          childExternalResolvers: true,
         },
       })
       .then(toDto);
   }
 
-  async getMany(pagination: PaginationDto): Promise<ExternalResolverSetDto[]> {
-    return this.prisma.externalResolverSet
+  async getMany(pagination: PaginationDto): Promise<ExternalResolverDto[]> {
+    return this.prisma.externalResolver
       .findMany({
-        include: {
-          resolvers: true,
-        },
+        include: Include,
         orderBy: {
           pattern: "asc",
         },
@@ -40,71 +38,92 @@ export class ExternalResolverService {
       .then((models) => models?.map(toDto));
   }
 
-  async upsertExternalResolverSet(dto: UpsertExternalResolverSetDto) {
-    return this.prisma
-      .$transaction(async (tx) => {
-        const id = dto.id || uuid();
+  async upsertExternalResolverSet(dto: UpsertExternalResolverDto) {
+    return this.prisma.$transaction(async (tx) => {
+      const id = dto.id || uuid();
 
-        if (dto.id) {
-          await tx.externalResolver.deleteMany({
-            where: {
-              id: dto.id,
-            },
-          });
+      // Delete resolver, cascade delete children
+      if (dto.id) {
+        await tx.externalResolver.delete({
+          where: {
+            id: dto.id,
+          },
+        });
+      }
+
+      // Create primary resolver
+      await tx.externalResolver.create({
+        data: {
+          id,
+          qualifier: dto.qualifier,
+          pattern: dto.pattern,
+          href: dto.href,
+        },
+      });
+
+      async function createChildResolver(dto: UpsertExternalResolverDto) {
+        await tx.externalResolver.create({
+          data: {
+            parentExternalResolverId: id,
+            qualifier: dto.qualifier,
+            pattern: dto.pattern,
+            href: dto.href,
+          },
+        });
+
+        if (!dto?.childExternalResolvers) return;
+
+        for (const child of dto.childExternalResolvers) {
+          await createChildResolver(child);
         }
+      }
 
-        return tx.externalResolverSet.upsert({
+      // Create child resolvers
+      for (const child of dto.childExternalResolvers || []) {
+        createChildResolver(child);
+      }
+
+      return tx.externalResolver
+        .findUnique({
           where: {
             id,
           },
-          create: {
-            id,
-            pattern: dto.pattern,
-            resolvers: {
-              createMany: {
-                data: dto?.resolvers?.map((resolver) => ({
-                  pattern: resolver.pattern,
-                  href: resolver.href,
-                })),
-              },
-            },
-          },
-          update: {
-            id,
-            pattern: dto.pattern,
-            resolvers: {
-              createMany: {
-                data: dto?.resolvers?.map((resolver) => ({
-                  pattern: resolver.pattern,
-                  href: resolver.href,
-                })),
-              },
-            },
-          },
-          include: {
-            resolvers: true,
-          },
-        });
-      })
-      .then(toDto);
+          include: Include,
+        })
+        .then(toDto);
+    });
   }
 
   async delete(id: string): Promise<string> {
-    await this.prisma.linkset.delete({ where: { id } });
-
+    await this.prisma.externalResolver.delete({ where: { id } });
     return id;
   }
 }
 
-const prismaDto = Prisma.validator<Prisma.ExternalResolverSetDefaultArgs>()({
-  include: {
-    resolvers: true,
+// Supporting child depth of 5 arbitrarily for now, can be increased
+const Include = {
+  childExternalResolvers: {
+    include: {
+      childExternalResolvers: {
+        include: {
+          childExternalResolvers: {
+            include: {
+              childExternalResolvers: true,
+            },
+          },
+        },
+      },
+    },
   },
+};
+
+const prismaDto = Prisma.validator<Prisma.ExternalResolverDefaultArgs>()({
+  include: Include,
 });
 
-type PrismaDTO = Prisma.ExternalResolverSetGetPayload<typeof prismaDto>;
+type PrismaDTO = Prisma.ExternalResolverGetPayload<typeof prismaDto>;
 
-const toDto = (prismaDto: PrismaDTO): ExternalResolverSetDto => {
+const toDto = (prismaDto: PrismaDTO): ExternalResolverDto => {
   if (!prismaDto) return;
 
   return {
@@ -112,11 +131,8 @@ const toDto = (prismaDto: PrismaDTO): ExternalResolverSetDto => {
     pattern: prismaDto.pattern,
     updatedAt: prismaDto.updatedAt,
     createdAt: prismaDto.createdAt,
-    resolvers: prismaDto.resolvers?.map((r) => ({
-      href: r.href,
-      pattern: r.pattern,
-      createdAt: r.createdAt,
-      updatedAt: r.updatedAt,
-    })),
+    qualifier: prismaDto.qualifier,
+    href: prismaDto.href,
+    childExternalResolvers: prismaDto.childExternalResolvers?.map(toDto),
   };
 };

--- a/src/link-set/link-set.dto.ts
+++ b/src/link-set/link-set.dto.ts
@@ -14,6 +14,9 @@ export class UpsertLinkSetDto {
   @IsString()
   identifier: string;
 
+  @IsString()
+  qualifier: string;
+
   @IsArray()
   @Length(1)
   @ValidateNested({ each: true })
@@ -41,6 +44,9 @@ export class LinkSetDto {
 
   @IsString()
   identifier?: string;
+
+  @IsString()
+  qualifier: string;
 
   @IsArray()
   @Length(1)

--- a/src/link-set/link-set.service.ts
+++ b/src/link-set/link-set.service.ts
@@ -57,6 +57,7 @@ export class LinkSetService {
           },
           create: {
             id,
+            qualifier: dto.qualifier,
             identifier: dto.identifier,
             links: {
               createMany: {
@@ -71,6 +72,7 @@ export class LinkSetService {
           },
           update: {
             id,
+            qualifier: dto.qualifier,
             identifier: dto.identifier,
             links: {
               createMany: {
@@ -106,6 +108,7 @@ const toDto = (prismaDto: PrismaDTO): LinkSetDto => {
   return {
     id: prismaDto.id,
     identifier: prismaDto.identifier,
+    qualifier: prismaDto.qualifier,
     updatedAt: prismaDto.updatedAt,
     createdAt: prismaDto.createdAt,
     links: prismaDto.links?.map((l) => ({

--- a/src/resolver/resolver.controller.ts
+++ b/src/resolver/resolver.controller.ts
@@ -1,15 +1,15 @@
-import { Controller, Get, NotFoundException, Param, Res } from "@nestjs/common";
-import { Response } from "express";
+import { Controller, Get, NotFoundException, Req, Res } from "@nestjs/common";
+import { Request, Response } from "express";
 import { ResolverService } from "./resolver.service";
 
 @Controller()
 export class ResolverController {
   constructor(private readonly resolverService: ResolverService) {}
 
-  @Get(":identifier")
-  async resolve(@Param("identifier") identifier: string, @Res() res: Response) {
+  @Get("*")
+  async resolve(@Req() request: Request, @Res() res: Response) {
     try {
-      const result = await this.resolverService.resolve(identifier);
+      const result = await this.resolverService.resolve(request.path);
 
       if ("redirectUrl" in result && !!result.redirectUrl)
         return res.redirect(302, result.redirectUrl);

--- a/src/resolver/resolver.service.spec.ts
+++ b/src/resolver/resolver.service.spec.ts
@@ -1,4 +1,6 @@
+import { faker } from "@faker-js/faker";
 import { Test } from "@nestjs/testing";
+import { ExternalResolver, Link, Linkset } from "@prisma/client";
 import { PrismaService } from "../prisma/prisma.service";
 import { ResolverService } from "./resolver.service";
 
@@ -13,32 +15,216 @@ describe("ResolverService", () => {
 
     resolverService = moduleRef.get<ResolverService>(ResolverService);
     prismaService = moduleRef.get<PrismaService>(PrismaService);
+
+    // Mock prisma transaction
+    jest
+      .spyOn(prismaService, "$transaction")
+      .mockImplementation((callback) => callback(prismaService));
   });
 
   describe("resolve", () => {
-    describe("external resolvers", () => {
-      it("will match a identifier against external resolver configurations.", async () => {
+    describe("link sets", () => {
+      beforeEach(() => {
         jest
-          .spyOn(prismaService.externalResolverSet, "findMany")
-          .mockResolvedValue([
+          .spyOn(prismaService.externalResolver, "findMany")
+          .mockResolvedValue([]);
+      });
+
+      it("can resolve a single primary identifier and qualifier pair.", async () => {
+        const linkSet: Linkset & {
+          links: Link[];
+        } = {
+          id: "test-link-set",
+          qualifier: "01",
+          identifier: "09524000059109",
+          createdAt: faker.date.recent(),
+          updatedAt: faker.date.recent(),
+          parentLinkSetId: undefined,
+          links: [
             {
-              id: "test-set",
-              pattern: `^(N|3|S|Q|W|NA75|M|T).*`,
-              // @ts-ignore
-              // TODO: resolve type issues with prisma and mocking
-              resolvers: [
+              id: "test-link",
+              href: "https://example.com",
+              title: "Product Page",
+              relationType: "gs1:pip",
+              createdAt: faker.date.recent(),
+              updatedAt: faker.date.recent(),
+              lang: ["en"],
+              linksetId: "test-link-set",
+            },
+          ],
+        };
+
+        jest
+          .spyOn(prismaService.linkset, "findMany")
+          .mockResolvedValue([linkSet as Linkset]);
+
+        expect(await resolverService.resolve("/01/09524000059109")).toEqual({
+          linkSet: [
+            {
+              anchor: "/01/09524000059109",
+              "gs1:pip": [
                 {
-                  id: "new-south-whales",
-                  pattern: `^(N).*`,
-                  href: "https://nsw-pic.com",
+                  href: "https://example.com",
+                  title: "Product Page",
+                  lang: ["en"],
                 },
               ],
             },
-          ]);
-
-        expect(await resolverService.resolve("NSW123456")).toEqual({
-          redirectUrl: "https://nsw-pic.com/NSW123456",
+          ],
         });
+      });
+
+      it("can resolve a single primary identifier and qualifier pair, with a nested qualifier and identifier.", async () => {
+        const primaryLinkSet: Linkset & {
+          links: Link[];
+        } = {
+          id: "primary-link-set",
+          qualifier: "01",
+          identifier: "09524000059109",
+          createdAt: faker.date.recent(),
+          updatedAt: faker.date.recent(),
+          parentLinkSetId: undefined,
+          links: [
+            {
+              id: "primary-link",
+              href: "https://example.com/primary",
+              title: "Primary Product Page",
+              relationType: "gs1:pip",
+              createdAt: faker.date.recent(),
+              updatedAt: faker.date.recent(),
+              lang: ["en"],
+              linksetId: "primary-link-set",
+            },
+          ],
+        };
+
+        const secondaryLinkSet: Linkset & {
+          links: Link[];
+        } = {
+          id: "secondary-link-set",
+          qualifier: "21",
+          identifier: "1234",
+          createdAt: faker.date.recent(),
+          updatedAt: faker.date.recent(),
+          parentLinkSetId: "primary-link-set",
+          links: [
+            {
+              id: "secondary-pip-link",
+              href: "https://example.com/secondary",
+              title: "Secondary Product Page",
+              relationType: "gs1:pip",
+              createdAt: faker.date.recent(),
+              updatedAt: faker.date.recent(),
+              lang: ["en"],
+              linksetId: "secondary-link-set",
+            },
+            {
+              id: "secondary-foo-link",
+              href: "https://example.com/secondary-foo",
+              title: "Foo Page",
+              relationType: "gs1:foo",
+              createdAt: faker.date.recent(),
+              updatedAt: faker.date.recent(),
+              lang: ["en"],
+              linksetId: "secondary-link-set",
+            },
+          ],
+        };
+
+        jest.spyOn(prismaService.linkset, "findMany").mockResolvedValue([
+          // NOTE random order returned
+          secondaryLinkSet as Linkset,
+          primaryLinkSet as Linkset,
+        ]);
+
+        expect(
+          await resolverService.resolve("/01/09524000059109/21/1234"),
+        ).toEqual({
+          linkSet: [
+            {
+              anchor: "/01/09524000059109/21/1234",
+              // Assert: gs1:pip links are concatenated
+              "gs1:pip": [
+                {
+                  href: "https://example.com/primary",
+                  title: "Primary Product Page",
+                  lang: ["en"],
+                },
+                {
+                  href: "https://example.com/secondary",
+                  title: "Secondary Product Page",
+                  lang: ["en"],
+                },
+              ],
+              // Assert: secondary link added and returned
+              "gs1:foo": [
+                {
+                  href: "https://example.com/secondary-foo",
+                  title: "Foo Page",
+                  lang: ["en"],
+                },
+              ],
+            },
+          ],
+        });
+      });
+    });
+
+    describe("external resolvers.", () => {
+      beforeEach(() => {
+        jest.spyOn(prismaService.linkset, "findMany").mockResolvedValue([]);
+      });
+
+      it("can pattern match a primary qualifier and identifier.", async () => {
+        const externalResolver: ExternalResolver = {
+          id: "test-resolver",
+          pattern: `^(N).*`,
+          href: "https://primary.com",
+          qualifier: "PIC",
+          createdAt: faker.date.recent(),
+          updatedAt: faker.date.recent(),
+          parentExternalResolverId: undefined,
+        };
+
+        jest
+          .spyOn(prismaService.externalResolver, "findMany")
+          .mockResolvedValue([externalResolver]);
+
+        expect(await resolverService.resolve("/PIC/NSW123456")).toEqual({
+          redirectUrl: "https://primary.com/PIC/NSW123456",
+        });
+      });
+
+      it("can pattern match a primary qualifier and identifier, with a nested qualifier and identifier.", async () => {
+        const primaryResolver: ExternalResolver = {
+          id: "primary-resolver",
+          pattern: `^(N).*`,
+          href: "https://primary.com",
+          qualifier: "PIC",
+          createdAt: faker.date.recent(),
+          updatedAt: faker.date.recent(),
+          parentExternalResolverId: undefined,
+        };
+
+        const secondaryResolver: ExternalResolver = {
+          id: "secondary-resolver",
+          pattern: `^(BAR).*`,
+          href: "https://secondary.com",
+          qualifier: "FOO",
+          createdAt: faker.date.recent(),
+          updatedAt: faker.date.recent(),
+          parentExternalResolverId: "primary-resolver",
+        };
+
+        jest
+          .spyOn(prismaService.externalResolver, "findMany")
+          .mockResolvedValue([secondaryResolver, primaryResolver]);
+
+        expect(await resolverService.resolve("/PIC/NSW123456/FOO/BAR")).toEqual(
+          {
+            redirectUrl: "https://secondary.com/PIC/NSW123456/FOO/BAR",
+          },
+        );
       });
     });
   });

--- a/src/resolver/resolver.service.ts
+++ b/src/resolver/resolver.service.ts
@@ -1,50 +1,174 @@
 import { Injectable } from "@nestjs/common";
-import { groupBy, mapValues } from "lodash";
+import { ExternalResolver, Link, Prisma } from "@prisma/client";
+import { mapValues } from "lodash";
 import { PrismaService } from "../prisma/prisma.service";
 import { LinkDto, ResolvedLinkSetDto } from "./resolver.dto";
+import { parseUrlPath } from "./utils";
 
 @Injectable()
 export class ResolverService {
   constructor(private readonly prisma: PrismaService) {}
 
   async resolve(
-    identifier: string,
+    path: string,
     linkType?: string,
   ): Promise<{ redirectUrl: string } | ResolvedLinkSetDto> {
-    // Load external resolver configurations
-    const resolverConfigs = await this.prisma.externalResolverSet.findMany({
-      include: {
-        resolvers: true,
+    // Extract segments
+    const segments = parseUrlPath(path);
+
+    // No segments, no link sets
+    if (segments.length === 0) {
+      return null;
+    }
+
+    // Extract primary qualifier/identifier pair
+    const { qualifier: primaryQualifier, identifier: primaryIdentifier } =
+      segments[0];
+
+    // Construct where clause
+    const linksetWhere: Prisma.LinksetWhereInput = {
+      OR: [{ qualifier: primaryQualifier, identifier: primaryIdentifier }],
+    };
+
+    const externalWhere: Prisma.ExternalResolverWhereInput = {
+      OR: [{ qualifier: primaryQualifier }],
+    };
+
+    // Starting from the second segment
+    for (let i = 1; i < segments.length; i++) {
+      const { qualifier, identifier } = segments[i];
+
+      linksetWhere.OR.push({
+        qualifier,
+        identifier,
+        parentLinkSet: {
+          // Child of previous qualifier/identifier
+          identifier: segments[i - 1].identifier,
+          qualifier: segments[i - 1].qualifier,
+        },
+      });
+
+      externalWhere.OR.push({
+        qualifier,
+        parentExternalResolver: {
+          qualifier: segments[i - 1].qualifier,
+        },
+      });
+    }
+
+    // TODO: This can be simplified, but
+    // unsure how to mock prisma.$transaction([prisma.linkset.findMany, prisma.externalResolver.findMany])
+    const [linkSets, externalResolvers] = await this.prisma.$transaction(
+      (tx) => {
+        return Promise.all([
+          tx.linkset.findMany({
+            where: linksetWhere,
+            include: {
+              links: true,
+            },
+          }),
+          tx.externalResolver.findMany({
+            where: externalWhere,
+          }),
+        ]);
       },
+    );
+
+    const treeNodes: ResolverTreeNode[] = [];
+    const rootIds: string[] = [];
+
+    // Sort external resolvers such that parents come first
+    const sortedExternalResolvers = externalResolvers.sort((a, b) => {
+      if (a.parentExternalResolverId && !b.parentExternalResolverId) return 1;
+      else if (!a.parentExternalResolverId && b.parentExternalResolverId)
+        return -1;
+
+      return 0;
     });
 
-    for (const config of resolverConfigs) {
-      // Test parent configuration
-      const parentPattern = new RegExp(config.pattern);
+    sortedExternalResolvers.forEach((resolver) => {
+      const node = new ResolverTreeNode(
+        resolver,
+        !resolver.parentExternalResolverId,
+      );
 
-      // Test child configurations
-      if (parentPattern.test(identifier)) {
-        for (const resolver of config.resolvers) {
-          const childPattern = new RegExp(resolver.pattern);
-          if (childPattern.test(identifier)) {
-            return {
-              redirectUrl: `${resolver.href}/${identifier}`,
-            };
-          }
+      treeNodes.push(node);
+
+      // Find parent and add as child
+      if (!!resolver.parentExternalResolverId) {
+        const parent = treeNodes.find(
+          (node) => node.id == resolver.parentExternalResolverId,
+        );
+
+        parent.addChild(node);
+      }
+      // Else, mark and track root
+      else {
+        rootIds.push(node.id);
+      }
+    });
+
+    // Extract root nodes
+    const rootNodes = treeNodes.filter((node) => rootIds.includes(node.id));
+    let maxDepth = -1;
+    let maxDepthNode: ResolverTreeNode;
+
+    function traverseTree(
+      node: ResolverTreeNode,
+      nodes: ResolverTreeNode[],
+      depth: number,
+    ) {
+      const { identifier } = segments[depth];
+
+      // If pattern matches, traverse to child
+      if (new RegExp(node.resolver.pattern).test(identifier)) {
+        // Check if this is the deepest node
+        if (depth > maxDepth) {
+          maxDepth = depth;
+          maxDepthNode = node;
         }
+
+        node.children.forEach((child) => {
+          traverseTree(child, nodes, depth + 1);
+        });
       }
     }
 
-    const linkSet = await this.prisma.linkset.findUnique({
-      where: { identifier },
-      include: {
-        links: true,
-      },
+    // For all resolver trees found, traverse and find greatest depth
+    rootNodes.forEach((root) => {
+      traverseTree(root, treeNodes, 0);
     });
 
-    const groupedLinkType = groupBy(linkSet?.links, (l) => l.relationType);
+    if (maxDepthNode) {
+      return {
+        redirectUrl: `${maxDepthNode.resolver.href}${path}`,
+      };
+    }
 
-    const mappedLinks = mapValues(groupedLinkType, (links) =>
+    // Sort link sets by depth in requested url path
+    const sortedLinkSets = linkSets.sort((a, b) => {
+      const indexA = segments.findIndex(
+        (seg) => seg.identifier == a.identifier && seg.qualifier == a.qualifier,
+      );
+
+      const indexB = segments.findIndex(
+        (seg) => seg.identifier == b.identifier && seg.qualifier == b.qualifier,
+      );
+
+      return indexA - indexB;
+    });
+
+    // Flatten link sets returned
+    const flattenedLinks: { [relationType: string]: Link[] } = {};
+    sortedLinkSets.forEach((linkSet) => {
+      linkSet.links.forEach((link) => {
+        if (!flattenedLinks[link.relationType])
+          flattenedLinks[link.relationType] = [];
+        flattenedLinks[link.relationType].push(link);
+      });
+    });
+
+    const mappedLinks = mapValues(flattenedLinks, (links) =>
       links.map(
         (l) =>
           ({
@@ -61,7 +185,7 @@ export class ResolverService {
         // TODO: how to get class-validator to work with key-values
         {
           // TODO: construct anchor url
-          anchor: identifier,
+          anchor: path,
           ...mappedLinks,
         },
       ],
@@ -79,5 +203,22 @@ export class ResolverService {
         },
       ],
     };
+  }
+}
+
+class ResolverTreeNode {
+  public children: ResolverTreeNode[] = [];
+
+  public get id() {
+    return this.resolver.id;
+  }
+
+  constructor(
+    public resolver: ExternalResolver,
+    public root?: boolean,
+  ) {}
+
+  addChild(node: ResolverTreeNode) {
+    this.children.push(node);
   }
 }

--- a/src/resolver/utils.spec.ts
+++ b/src/resolver/utils.spec.ts
@@ -1,0 +1,59 @@
+import { parseUrlPath } from "./utils";
+
+describe("utils", () => {
+  describe("parseUrlPath", () => {
+    it("can identify the primary qualifier and primary identifier.", () => {
+      const results = parseUrlPath("/01/09524000059109");
+
+      expect(results[0]).toEqual({
+        qualifier: "01",
+        identifier: "09524000059109",
+      });
+    });
+
+    it("can identify primary, and deeply nested qualifiers and identifiers.", () => {
+      const results = parseUrlPath("/01/09524000059109/21/1234");
+
+      expect(results).toEqual([
+        {
+          qualifier: "01",
+          identifier: "09524000059109",
+        },
+        {
+          qualifier: "21",
+          identifier: "1234",
+        },
+      ]);
+    });
+
+    it("can ignore arbitrary query strings.", () => {
+      const results = parseUrlPath("/01/09524000059109/21/1234?foo=bar");
+
+      expect(results).toEqual([
+        {
+          qualifier: "01",
+          identifier: "09524000059109",
+        },
+        {
+          qualifier: "21",
+          identifier: "1234",
+        },
+      ]);
+    });
+
+    it("will ignore odd segments", () => {
+      const results = parseUrlPath("/01/09524000059109/21/1234/123?foo=bar");
+
+      expect(results).toEqual([
+        {
+          qualifier: "01",
+          identifier: "09524000059109",
+        },
+        {
+          qualifier: "21",
+          identifier: "1234",
+        },
+      ]);
+    });
+  });
+});

--- a/src/resolver/utils.ts
+++ b/src/resolver/utils.ts
@@ -1,0 +1,25 @@
+type QualifierIdentifier = {
+  readonly qualifier: string;
+  readonly identifier: string;
+};
+
+export function parseUrlPath(urlPath: string): QualifierIdentifier[] {
+  const cleanPath = urlPath.split("?")[0];
+  const segments = cleanPath.split("/").filter((segment) => segment.length > 0);
+
+  const result: QualifierIdentifier[] = [];
+
+  for (let i = 0; i < segments.length; i += 2) {
+    const qualifier = segments[i];
+    const identifier = segments[i + 1];
+
+    if (qualifier && identifier) {
+      result.push({
+        qualifier: segments[i],
+        identifier: segments[i + 1],
+      });
+    }
+  }
+
+  return result;
+}

--- a/test/link-set.e2e-spec.ts
+++ b/test/link-set.e2e-spec.ts
@@ -34,6 +34,7 @@ describe("LinkSet (e2e)", () => {
   it("/link-sets (POST)", async () => {
     const dto: UpsertLinkSetDto = {
       identifier: "09524000059109",
+      qualifier: "01",
       links: [
         {
           relationType: "describedBy",
@@ -52,6 +53,7 @@ describe("LinkSet (e2e)", () => {
         expect(response.body).toEqual(
           expect.objectContaining({
             identifier: "09524000059109",
+            qualifier: "01",
             links: [
               expect.objectContaining({
                 relationType: "describedBy",
@@ -65,14 +67,14 @@ describe("LinkSet (e2e)", () => {
       });
 
     await request(app.getHttpServer())
-      .get("/09524000059109")
+      .get("/01/09524000059109")
       .expect(200)
       .expect((response) => {
         expect(response.body).toEqual(
           expect.objectContaining({
             linkSet: [
               expect.objectContaining({
-                anchor: "09524000059109",
+                anchor: "/01/09524000059109",
                 describedBy: [
                   {
                     href: "https://example.com",
@@ -98,6 +100,7 @@ describe("LinkSet (e2e)", () => {
 
     const dto: UpsertLinkSetDto = {
       identifier: "09524000059109",
+      qualifier: "01",
       links: [
         {
           relationType: "describedBy",
@@ -117,6 +120,7 @@ describe("LinkSet (e2e)", () => {
         expect(response.body).toEqual(
           expect.objectContaining({
             identifier: "09524000059109",
+            qualifier: "01",
             links: [
               expect.objectContaining({
                 relationType: "describedBy",
@@ -137,6 +141,7 @@ describe("LinkSet (e2e)", () => {
           expect.objectContaining({
             id: dtoResponse.id,
             identifier: "09524000059109",
+            qualifier: "01",
             links: [
               expect.objectContaining({
                 relationType: "describedBy",
@@ -165,6 +170,7 @@ describe("LinkSet (e2e)", () => {
           prismaService.linkset.create({
             data: {
               identifier: `09524000059109${index}`,
+              qualifier: "01",
               links: {
                 createMany: {
                   data: [
@@ -209,6 +215,7 @@ describe("LinkSet (e2e)", () => {
 
     const dto: UpsertLinkSetDto = {
       identifier: "09524000059109",
+      qualifier: "01",
       links: [
         {
           relationType: "describedBy",
@@ -228,6 +235,7 @@ describe("LinkSet (e2e)", () => {
         expect(response.body).toEqual(
           expect.objectContaining({
             identifier: "09524000059109",
+            qualifier: "01",
             links: [
               expect.objectContaining({
                 relationType: "describedBy",


### PR DESCRIPTION
- Supporting deeply nested qualifier and identifier path segments. 
- Resolving link sets based on paths, and matched against their qualifier/identifier pairs.
- Link sets results are concatenated based on the depth of qualifier/identifiers matched. 
- External resolvers support arbitrary qualifier/identifier depth matching. 
- On link resolution, multiple tree data structures are formed based on qualifiers in path.
- Trees are iterated until the deepest node is found, and redirectUrl is returned as such.
- Currently, equal depth nodes are not handled in any predictable manner. 